### PR TITLE
Switch Genbank uploader and downloader to use AssemblyUtil

### DIFF
--- a/kbase.yml
+++ b/kbase.yml
@@ -8,8 +8,8 @@ service-language:
     python
 
 module-version:
-    0.6.4
+    0.6.5
 
 owners:
-    [jkbaumohl, msneddon, mhenderson, rsutormin]
+    [jkbaumohl, msneddon, rsutormin]
 


### PR DESCRIPTION
Previously we were using a direct call to an old transform script (uploader), and the data_api (downloader) to fetch assembly information.  Now we get that directly through the AssemblyUtil module.