### PR TITLE
Prevent genome downgrade

### DIFF
--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.7.3
+    0.7.4
 
 owners:
     [jkbaumohl, jjeffryes]

--- a/lib/GenomeFileUtil/core/GenomeToGFF.py
+++ b/lib/GenomeFileUtil/core/GenomeToGFF.py
@@ -41,6 +41,7 @@ class GenomeToGFF:
                 'ref':params['genome_ref']
             }],
             'included_fields':['gff_handle_ref'],
+            'downgrade': 0,
             'ignore_errors':0 # if we can't find the genome, throw an error
         }
         if 'ref_path_to_genome' in params:


### PR DESCRIPTION
This fix addresses issues in the RNAseq pipeline (kb_stringtie in particular) cause by the old GFF downloader interacting with the new genome annotation API. This PR includes a parameter to prevent downgrading the genome which causes the incompatibility.