### PR TITLE
Stop using non-protein_encoding_gene in place of non_coding_features

### DIFF
--- a/lib/GenomeFileUtil/core/FastaGFFToGenome.py
+++ b/lib/GenomeFileUtil/core/FastaGFFToGenome.py
@@ -893,7 +893,7 @@ class FastaGFFToGenome:
                     feature.pop('mrnas', None)
                     feature.pop('cdss', None)
                     feature.pop('protein_translation_length', None)
-                    self.feature_counts["non-protein_encoding_gene"] += 1
+                    self.feature_counts["non_coding_features"] += 1
                     genome['non_coding_features'].append(feature)
             else:
                 genome['non_coding_features'].append(feature)

--- a/lib/GenomeFileUtil/core/GenbankToGenome.py
+++ b/lib/GenomeFileUtil/core/GenbankToGenome.py
@@ -618,7 +618,7 @@ class GenbankToGenome:
             else:
                 del g['mrnas'], g['cdss']
                 self.noncoding.append(g)
-                self.feature_counts["non-protein_encoding_gene"] += 1
+                self.feature_counts["non_coding_features"] += 1
         return {'features': coding, 'non_coding_features': self.noncoding,
                 'cdss': list(self.cdss.values()), 'mrnas': list(self.mrnas.values())}
 

--- a/lib/GenomeFileUtil/core/GenomeInterface.py
+++ b/lib/GenomeFileUtil/core/GenomeInterface.py
@@ -389,7 +389,7 @@ class GenomeInterface:
         type_counts['mRNA'] = len(genome.get('mrnas', []))
         type_counts['CDS'] = len(genome.get('cdss', []))
         type_counts['protein_encoding_gene'] = len(genome['features'])
-        type_counts['non-protein_encoding_gene'] = len(
+        type_counts['non_coding_features'] = len(
             genome.get('non_coding_features', []))
         genome['feature_counts'] = type_counts
 


### PR DESCRIPTION
@JamesJeffryes - PTV-1160 - Missing repeats in the Genome Object.
It seems that 'non-protein_encoding_gene' and 'non_coding_features' were both used for the same thing. The data spec uses non_coding_features so I made three changes to make this consistent. I'd like to test this in CI dev with the RAST-SDK that I'm testing.