### PR TITLE
Replace indexed based lookup with dictionary lookup

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.6] - 2022-01-29
+Fixed performance issue with FastaGFF impacting metagenome uploads
+
 ## [0.11.5] - 2021-3-16
 Fixed issue with empty GFF download file PTV-1637
 


### PR DESCRIPTION
This is to address a performance issue that was seen when uploading
large metagenomes.  The FastaGFF uploader using an index call to
get the contig_length.  This winds up being slow when there are
10M plus contigs.  Fortunately there was already a dict of the
same information.  I'm not sure why that wasn't used in the first
place.  Testing shows this gives linear performance even for
very large metagenomes.